### PR TITLE
Update dependencies and add Travis CI config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,46 @@
+language: c
+
+# explicitly request container-based infrastructure
+sudo: false
+
+matrix:
+  include:
+    - env: CABALVER=1.18 GHCVER=7.8.4
+      addons: {apt: {packages: [cabal-install-1.18,happy-1.19.5,ghc-7.8.4], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.1
+      addons: {apt: {packages: [cabal-install-1.22,happy-1.19.5,ghc-7.10.1],sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.2
+      addons: {apt: {packages: [cabal-install-1.22,happy-1.19.5,ghc-7.10.2],sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3
+      addons: {apt: {packages: [cabal-install-1.22,happy-1.19.5,ghc-7.10.3],sources: [hvr-ghc]}}
+    - env: CABALVER=head GHCVER=head
+      addons: {apt: {packages: [cabal-install-head,happy-1.19.5,ghc-head],  sources: [hvr-ghc]}}
+
+  allow_failures:
+   - env: CABALVER=head GHCVER=head
+
+before_install:
+ - export HAPPYVER=1.19.5
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:/opt/happy/$HAPPYVER/bin:$PATH
+
+install:
+ - cabal --version
+ - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ - travis_retry cabal update
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks
+
+# Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
+script:
+ - if [ -f configure.ac ]; then autoreconf -i; fi
+ - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
+ - cabal build   # this builds all libraries and executables (including tests/benchmarks)
+ - cabal test
+ - cabal check
+ - cabal sdist   # tests that a source-distribution can be generated
+
+# Check that the resulting source distribution can be built & installed.
+# If there are no other `.tar.gz` files in `dist`, this can be even simpler:
+# `cabal install --force-reinstalls dist/*-*.tar.gz`
+ - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
+   (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
+

--- a/hscope.cabal
+++ b/hscope.cabal
@@ -41,8 +41,8 @@ Extra-Source-Files:
 Executable hscope
     Main-Is: HScope.hs
     GHC-Options: -Wall
-    Build-Depends: base >= 4.7 && < 4.9
-                             , haskell-src-exts == 1.16.*, mtl, pure-cdb
+    Build-Depends: base >= 4.7 && < 5
+                             , haskell-src-exts == 1.17.*, mtl, pure-cdb
                              , uniplate >= 1.6.12 && < 1.7, cereal
                              , vector, bytestring, process, deepseq, directory, cpphs
     Default-Language: Haskell2010

--- a/t/Build.hs
+++ b/t/Build.hs
@@ -55,7 +55,7 @@ main = withTemporaryDirectory "/tmp/hscope_test_XXXXXX" $ \td -> testSimpleMain 
     like l4 "parseFlags ::"
     like l4 "groupBy (==)"
 
-    res6 <- liftIO $ readProcess hpath [ "-b", "-f", td ++ "/foo.out", "t/files/a.c" ] ""
+    res6 <- liftIO $ readProcess hpath [ "-b", "-f", td ++ "/foo.out", "-X", "NamedFieldPuns", "t/files/a.c" ] ""
     like res6 "Parse error: 0"
     like res6 "a.c"
 

--- a/t/files/garrs.hs
+++ b/t/files/garrs.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE GADTs #-}
+
 data G a where
     A :: a -> G Int
     B :: b -> G Bool


### PR DESCRIPTION
Update dependencies to get closer to being compatible with Stackage LTS.  Added Travis CI config that tests GHC 7.8.4, 7.10.1, 7.10.2, 7.10.3, and 8.1 (head, at the time of this writing).

Had to update a couple tests to get them to pass.  The one that is concerning is the `a.c` test.  The behavior has changed from haskell-src-exts-0.16.* to 0.17.*, so I added the `NamedFieldPuns` extension to get the test to pass.  This should likely be revisited.

Travis results available [here](https://travis-ci.org/jship/hscope).

Note that this makes progress on #11.  pure-cdb will have to be added to LTS, but afterwards, it looks like hscope will be compatible with LTS too.